### PR TITLE
fix: corrigir bootstrap do MinIO e Kafka

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,9 @@ services:
     volumes:
       - ./infra/kafka/config:/kafka/config
 
-  kafka-init:
+  init-kafka:
     image: confluentinc/cp-kafka:7.3.0
-    container_name: kafka-init
+    container_name: init-kafka
     networks:
       - lambda-net
     depends_on:
@@ -48,6 +48,9 @@ services:
     command: -c "/scripts/init-kafka.sh"
     volumes:
       - ./infra/kafka:/scripts
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+    restart: on-failure
 
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
@@ -79,9 +82,9 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
     command: server /data --console-address ":9001"
 
-  minio-client:
+  init-minio:
     image: minio/mc
-    container_name: minio-client
+    container_name: init-minio
     networks:
       - lambda-net
     depends_on:
@@ -90,6 +93,10 @@ services:
     command: -c "/scripts/init-minio.sh"
     volumes:
       - ./infra/minio:/scripts
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    restart: on-failure
 
   # ---------------------------------------------------------------------------
   # 3) SERVING LAYER - MySQL

--- a/infra/kafka/init-kafka.sh
+++ b/infra/kafka/init-kafka.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
 set -e
 
+: "${KAFKA_BOOTSTRAP_SERVERS:=kafka:29092}"
+
 echo "======================================"
 echo " Kafka bootstrap — criando tópicos"
 echo "======================================"
 
-echo "Aguardando Kafka ficar disponível..."
-cub kafka-ready -b kafka:29092 1 60
+echo "Aguardando Kafka ficar disponível (operação real)..."
+
+until kafka-topics --bootstrap-server "$KAFKA_BOOTSTRAP_SERVERS" --list >/dev/null 2>&1; do
+  echo "Kafka ainda não pronto para operações..."
+  sleep 5
+done
 
 echo "Kafka disponível. Criando tópicos..."
 
-# -------------------------------------------------
-# Tópico: transações brutas (ingestão)
-# -------------------------------------------------
 kafka-topics \
-  --bootstrap-server kafka:29092 \
+  --bootstrap-server "$KAFKA_BOOTSTRAP_SERVERS" \
   --create \
   --topic transactions_raw \
   --partitions 3 \
@@ -23,11 +26,8 @@ kafka-topics \
 
 echo "Tópico 'transactions_raw' OK"
 
-# -------------------------------------------------
-# (Opcional) Tópico: transações analisadas
-# -------------------------------------------------
 kafka-topics \
-  --bootstrap-server kafka:29092 \
+  --bootstrap-server "$KAFKA_BOOTSTRAP_SERVERS" \
   --create \
   --topic transactions_scored \
   --partitions 3 \

--- a/infra/minio/init-minio.sh
+++ b/infra/minio/init-minio.sh
@@ -7,9 +7,14 @@ echo "======================================"
 
 echo "Aguardando MinIO ficar disponível..."
 
-until mc alias set local http://minio:9000 minioadmin minioadmin; do
-    echo "MinIO ainda não disponível, aguardando..."
-    sleep 5
+until mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+    echo "MinIO ainda não disponível (alias)..."
+    sleep 3
+done
+
+until mc ls local >/dev/null 2>&1; do
+    echo "MinIO ainda não pronto para operações..."
+    sleep 3
 done
 
 echo "MinIO disponível. Criando buckets..."


### PR DESCRIPTION
## O que foi feito
- Correção dos scripts de init do MinIO e Kafka
- Ajuste de readiness real antes da criação de buckets e tópicos
- Correção de quebra por CRLF em ambientes Windows
- Padronização do uso de variáveis de ambiente no Kafka init

## Resultado
- Buckets do MinIO criados automaticamente no startup
- Tópicos do Kafka criados de forma idempotente
- Containers de init executam uma única vez e encerram corretamente

## Impacto
- Apenas infraestrutura de desenvolvimento
- Sem impacto funcional na aplicação
