### PR TITLE
Fix init containers de Kafka e MinIO para Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,16 +38,12 @@ services:
       - ./infra/kafka/config:/kafka/config
 
   init-kafka:
-    image: confluentinc/cp-kafka:7.3.0
+    build: ./infra/kafka
     container_name: init-kafka
     networks:
       - lambda-net
     depends_on:
       - kafka
-    entrypoint: /bin/bash
-    command: -c "/scripts/init-kafka.sh"
-    volumes:
-      - ./infra/kafka:/scripts
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
     restart: on-failure
@@ -83,16 +79,12 @@ services:
     command: server /data --console-address ":9001"
 
   init-minio:
-    image: minio/mc
+    build: ./infra/minio
     container_name: init-minio
     networks:
       - lambda-net
     depends_on:
       - minio
-    entrypoint: /bin/sh
-    command: -c "/scripts/init-minio.sh"
-    volumes:
-      - ./infra/minio:/scripts
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin

--- a/infra/kafka/Dockerfile
+++ b/infra/kafka/Dockerfile
@@ -1,0 +1,8 @@
+FROM confluentinc/cp-kafka:7.3.0
+
+USER root
+
+COPY init-kafka.sh /init-kafka.sh
+RUN chmod +x /init-kafka.sh
+
+ENTRYPOINT ["/init-kafka.sh"]

--- a/infra/minio/Dockerfile
+++ b/infra/minio/Dockerfile
@@ -1,0 +1,8 @@
+FROM minio/mc
+
+USER root
+
+COPY init-minio.sh /init-minio.sh
+RUN chmod +x /init-minio.sh
+
+ENTRYPOINT ["/init-minio.sh"]


### PR DESCRIPTION
## O que foi feito

- Criados Dockerfiles dedicados para os init containers de Kafka e MinIO
- Removida a dependência de scripts montados via volume
- Scripts de bootstrap agora são copiados para a imagem e executados via ENTRYPOINT
- Mantida lógica de espera e idempotência na criação de tópicos e buckets

## Por que foi feito

Em ambientes Linux, volumes vindos do filesystem do Windows/OneDrive são montados como `noexec`,
o que impedia a execução dos scripts de init, mesmo com permissões corretas.

Esse ajuste garante:
- Comportamento consistente entre Windows e Linux
- Setup mais previsível e reproduzível
- Menos dependência do ambiente local

## Como testar

```bash
docker compose down -v
docker compose build --no-cache
docker compose up
